### PR TITLE
Add support for allowed.templates option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -62,8 +62,12 @@ c::set('sitemap.include.invisible', false);
 // URI of pages to remove
 c::set('sitemap.ignored.pages', []);
 
-// Templates names to remove
+// Template names to remove
 c::set('sitemap.ignored.templates', []);
+
+// or only include the following Templates
+c::set('sitemap.allowed.templates', []);
+// NOTE: You can only use ignored.templates or allowed.templates, not both.
 
 // Show/hide change frequency attribute
 // (see more below)

--- a/snippets/page.php
+++ b/snippets/page.php
@@ -4,7 +4,13 @@
 
     <?php if ($languages && $languages->count() > 1) : ?>
     <?php foreach ($languages as $lang) : ?>
+        <?php
+        // only print the URL if the page has translated content and the url
+        // is different than the standard URL
+        if ($page->content($lang->code())->exists() &&
+            $page->url() !== $page->url($lang->code())) : ?>
     <xhtml:link hreflang="<?= $lang->code() ?>" href="<?= html($page->url($lang->code())) ?>" rel="alternate" />
+        <?php endif; ?>
     <?php endforeach ?>
     <?php endif ?>
 

--- a/xml-sitemap.php
+++ b/xml-sitemap.php
@@ -34,6 +34,7 @@ kirby()->set('route', [
         $includeInvisibles = c::get('sitemap.include.invisible', false);
         $ignoredPages      = c::get('sitemap.ignored.pages', []);
         $ignoredTemplates  = c::get('sitemap.ignored.templates', []);
+        $allowedTemplates  = c::get('sitemap.allowed.templates', []);
 
         if (! is_array($ignoredPages)) {
             throw new Exception('The option "sitemap.ignored.pages" must be an array.');
@@ -43,6 +44,14 @@ kirby()->set('route', [
             throw new Exception('The option "sitemap.ignored.templates" must be an array.');
         }
 
+        if (! is_array($allowedTemplates)) {
+            throw new Exception('The option "sitemap.allowed.templates" must be an array.');
+        }
+
+        if (count($allowedTemplates) > 0 && count($ignoredTemplates) > 0) {
+            throw new Exception('You can only set option "sitemap.allowed.templates" or "sitemap.ignored.templates", not both');
+        }
+
         $languages = site()->languages();
         $pages     = site()->index();
 
@@ -50,10 +59,17 @@ kirby()->set('route', [
             $pages = $pages->visible();
         }
 
-        $pages = $pages
-                    ->not($ignoredPages)
-                    ->filterBy('intendedTemplate', 'not in', $ignoredTemplates)
-                    ->map('sitemapProcessAttributes');
+        if (count($ignoredTemplates) > 0) {
+            $pages = $pages
+                ->not($ignoredPages)
+                ->filterBy('intendedTemplate', 'not in', $ignoredTemplates)
+                ->map('sitemapProcessAttributes');
+        } else {
+            $pages = $pages
+                ->not($ignoredPages)
+                ->filterBy('intendedTemplate', 'in', $allowedTemplates)
+                ->map('sitemapProcessAttributes');
+        }
 
         $process = c::get('sitemap.process', null);
 


### PR DESCRIPTION
Hi Pedro..

I just saw your comment on the other open pull request, so maybe you won't find this so useful.  In any case, I added support to filter on template by only including specific templates.

For us this was better because we are using the kirby-modules plugin and we generate a ton modules that shouldn't show up in a sitemap.

You can feel free to merge or reject as you wish.  The change is trivial.